### PR TITLE
Disable ext_data service

### DIFF
--- a/sparse/usr/libexec/droid-hybris/system/etc/init/disabled_services.rc
+++ b/sparse/usr/libexec/droid-hybris/system/etc/init/disabled_services.rc
@@ -63,3 +63,5 @@ service ip_monitor /system_ext/bin/ip_monitor.sh_HYBRIS_DISABLED
 service remotedisplay /system/bin/remotedisplay_HYBRIS_DISABLED
 
 service credstore /system/bin/credstore_HYBRIS_DISABLED
+
+service ext_data /system_ext/bin/ext_data_HYBRIS_DISABLED


### PR DESCRIPTION
This service seems to set /proc/net values for IPv4/IPv6 that conflict with ones we need. Disable the service to allow us to define them with, e.g., /etc/sysctl.d/*.conf files.