### PR TITLE
s19mps: Fix pulseaudio crash on exit

### DIFF
--- a/sparse/etc/pulse/arm_droid_card_custom.pa
+++ b/sparse/etc/pulse/arm_droid_card_custom.pa
@@ -1,2 +1,2 @@
-load-module module-droid-card rate=48000 hw_volume=false
+load-module module-droid-card rate=48000 hw_volume=false unload_call_exit=true
 load-module module-udev-detect


### PR DESCRIPTION
Pulseaudio crashed when unloading audio hw module, use the unload_call_exit quirk to prevent that from happening.