### PR TITLE
Add IPv6 configs for all seth_lte* adapter

### DIFF
--- a/sparse/usr/lib/sysctl.d/90-seth_lte0-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte0-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte0.accept_dad = 1
+net.ipv6.conf.seth_lte0.accept_ra = 2
+net.ipv6.conf.seth_lte0.accept_redirects = 0
+net.ipv6.conf.seth_lte0.hop_limit = 255
+net.ipv6.conf.seth_lte0.optimistic_dad = 1
+net.ipv6.conf.seth_lte0.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte0.use_tempaddr = 2
+net.ipv6.conf.seth_lte0.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte0.mtu = 2000
+net.ipv6.neigh.seth_lte0.retrans_time = 10
+net.ipv6.neigh.seth_lte0.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte1-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte1-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte1.accept_dad = 1
+net.ipv6.conf.seth_lte1.accept_ra = 2
+net.ipv6.conf.seth_lte1.accept_redirects = 0
+net.ipv6.conf.seth_lte1.hop_limit = 255
+net.ipv6.conf.seth_lte1.optimistic_dad = 1
+net.ipv6.conf.seth_lte1.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte1.use_tempaddr = 2
+net.ipv6.conf.seth_lte1.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte1.mtu = 2000
+net.ipv6.neigh.seth_lte1.retrans_time = 10
+net.ipv6.neigh.seth_lte1.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte10-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte10-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte10.accept_dad = 1
+net.ipv6.conf.seth_lte10.accept_ra = 2
+net.ipv6.conf.seth_lte10.accept_redirects = 0
+net.ipv6.conf.seth_lte10.hop_limit = 255
+net.ipv6.conf.seth_lte10.optimistic_dad = 1
+net.ipv6.conf.seth_lte10.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte10.use_tempaddr = 2
+net.ipv6.conf.seth_lte10.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte10.mtu = 2000
+net.ipv6.neigh.seth_lte10.retrans_time = 10
+net.ipv6.neigh.seth_lte10.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte11-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte11-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte11.accept_dad = 1
+net.ipv6.conf.seth_lte11.accept_ra = 2
+net.ipv6.conf.seth_lte11.accept_redirects = 0
+net.ipv6.conf.seth_lte11.hop_limit = 255
+net.ipv6.conf.seth_lte11.optimistic_dad = 1
+net.ipv6.conf.seth_lte11.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte11.use_tempaddr = 2
+net.ipv6.conf.seth_lte11.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte11.mtu = 2000
+net.ipv6.neigh.seth_lte11.retrans_time = 10
+net.ipv6.neigh.seth_lte11.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte12-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte12-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte12.accept_dad = 1
+net.ipv6.conf.seth_lte12.accept_ra = 2
+net.ipv6.conf.seth_lte12.accept_redirects = 0
+net.ipv6.conf.seth_lte12.hop_limit = 255
+net.ipv6.conf.seth_lte12.optimistic_dad = 1
+net.ipv6.conf.seth_lte12.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte12.use_tempaddr = 2
+net.ipv6.conf.seth_lte12.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte12.mtu = 2000
+net.ipv6.neigh.seth_lte12.retrans_time = 10
+net.ipv6.neigh.seth_lte12.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte13-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte13-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte13.accept_dad = 1
+net.ipv6.conf.seth_lte13.accept_ra = 2
+net.ipv6.conf.seth_lte13.accept_redirects = 0
+net.ipv6.conf.seth_lte13.hop_limit = 255
+net.ipv6.conf.seth_lte13.optimistic_dad = 1
+net.ipv6.conf.seth_lte13.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte13.use_tempaddr = 2
+net.ipv6.conf.seth_lte13.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte13.mtu = 2000
+net.ipv6.neigh.seth_lte13.retrans_time = 10
+net.ipv6.neigh.seth_lte13.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte2-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte2-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte2.accept_dad = 1
+net.ipv6.conf.seth_lte2.accept_ra = 2
+net.ipv6.conf.seth_lte2.accept_redirects = 0
+net.ipv6.conf.seth_lte2.hop_limit = 255
+net.ipv6.conf.seth_lte2.optimistic_dad = 1
+net.ipv6.conf.seth_lte2.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte2.use_tempaddr = 2
+net.ipv6.conf.seth_lte2.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte2.mtu = 2000
+net.ipv6.neigh.seth_lte2.retrans_time = 10
+net.ipv6.neigh.seth_lte2.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte3-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte3-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte3.accept_dad = 1
+net.ipv6.conf.seth_lte3.accept_ra = 2
+net.ipv6.conf.seth_lte3.accept_redirects = 0
+net.ipv6.conf.seth_lte3.hop_limit = 255
+net.ipv6.conf.seth_lte3.optimistic_dad = 1
+net.ipv6.conf.seth_lte3.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte3.use_tempaddr = 2
+net.ipv6.conf.seth_lte3.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte3.mtu = 2000
+net.ipv6.neigh.seth_lte3.retrans_time = 10
+net.ipv6.neigh.seth_lte3.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte4-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte4-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte4.accept_dad = 1
+net.ipv6.conf.seth_lte4.accept_ra = 2
+net.ipv6.conf.seth_lte4.accept_redirects = 0
+net.ipv6.conf.seth_lte4.hop_limit = 255
+net.ipv6.conf.seth_lte4.optimistic_dad = 1
+net.ipv6.conf.seth_lte4.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte4.use_tempaddr = 2
+net.ipv6.conf.seth_lte4.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte4.mtu = 2000
+net.ipv6.neigh.seth_lte4.retrans_time = 10
+net.ipv6.neigh.seth_lte4.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte5-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte5-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte5.accept_dad = 1
+net.ipv6.conf.seth_lte5.accept_ra = 2
+net.ipv6.conf.seth_lte5.accept_redirects = 0
+net.ipv6.conf.seth_lte5.hop_limit = 255
+net.ipv6.conf.seth_lte5.optimistic_dad = 1
+net.ipv6.conf.seth_lte5.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte5.use_tempaddr = 2
+net.ipv6.conf.seth_lte5.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte5.mtu = 2000
+net.ipv6.neigh.seth_lte5.retrans_time = 10
+net.ipv6.neigh.seth_lte5.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte6-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte6-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte6.accept_dad = 1
+net.ipv6.conf.seth_lte6.accept_ra = 2
+net.ipv6.conf.seth_lte6.accept_redirects = 0
+net.ipv6.conf.seth_lte6.hop_limit = 255
+net.ipv6.conf.seth_lte6.optimistic_dad = 1
+net.ipv6.conf.seth_lte6.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte6.use_tempaddr = 2
+net.ipv6.conf.seth_lte6.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte6.mtu = 2000
+net.ipv6.neigh.seth_lte6.retrans_time = 10
+net.ipv6.neigh.seth_lte6.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte7-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte7-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte7.accept_dad = 1
+net.ipv6.conf.seth_lte7.accept_ra = 2
+net.ipv6.conf.seth_lte7.accept_redirects = 0
+net.ipv6.conf.seth_lte7.hop_limit = 255
+net.ipv6.conf.seth_lte7.optimistic_dad = 1
+net.ipv6.conf.seth_lte7.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte7.use_tempaddr = 2
+net.ipv6.conf.seth_lte7.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte7.mtu = 2000
+net.ipv6.neigh.seth_lte7.retrans_time = 10
+net.ipv6.neigh.seth_lte7.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte8-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte8-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte8.accept_dad = 1
+net.ipv6.conf.seth_lte8.accept_ra = 2
+net.ipv6.conf.seth_lte8.accept_redirects = 0
+net.ipv6.conf.seth_lte8.hop_limit = 255
+net.ipv6.conf.seth_lte8.optimistic_dad = 1
+net.ipv6.conf.seth_lte8.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte8.use_tempaddr = 2
+net.ipv6.conf.seth_lte8.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte8.mtu = 2000
+net.ipv6.neigh.seth_lte8.retrans_time = 10
+net.ipv6.neigh.seth_lte8.retrans_time_ms = 10

--- a/sparse/usr/lib/sysctl.d/90-seth_lte9-ipv6.conf
+++ b/sparse/usr/lib/sysctl.d/90-seth_lte9-ipv6.conf
@@ -1,0 +1,11 @@
+net.ipv6.conf.seth_lte9.accept_dad = 1
+net.ipv6.conf.seth_lte9.accept_ra = 2
+net.ipv6.conf.seth_lte9.accept_redirects = 0
+net.ipv6.conf.seth_lte9.hop_limit = 255
+net.ipv6.conf.seth_lte9.optimistic_dad = 1
+net.ipv6.conf.seth_lte9.router_solicitation_interval = 4
+net.ipv6.conf.seth_lte9.use_tempaddr = 2
+net.ipv6.conf.seth_lte9.accept_ra_mtu = 0
+net.ipv6.conf.seth_lte9.mtu = 2000
+net.ipv6.neigh.seth_lte9.retrans_time = 10
+net.ipv6.neigh.seth_lte9.retrans_time_ms = 10


### PR DESCRIPTION
Add the IPv6 configs separately for each devices as adding these as net.ipv6.conf.all|default does not seem to work.