### PR TITLE
Set WPA3 support to none in ConnMan config.

### DIFF
--- a/sparse/etc/connman/main.conf.d/10-s19mps.conf
+++ b/sparse/etc/connman/main.conf.d/10-s19mps.conf
@@ -3,3 +3,4 @@
 NetworkInterfaceBlacklist = ifb,gretap,erspan,p2p,rndis,seth_lte
 DontBringDownAtStartup = usb
 FallbackDeviceTypes = usb0:gadget
+WifiWPA3Support = none


### PR DESCRIPTION
The driver reports and has WPA3 SAE support but firmware or something does not co-operate. Disable WPA3 support for now so WPA2, and WPA2+WPA3 mixed (in WPA2 security mode) can be used on this device.

Requires:
https://github.com/sailfishos/connman/pull/121
https://github.com/sailfishos/libgsupplicant/pull/5