### PR TITLE
s19mps: Use host AIDL power HAL in AppSupport

### DIFF
--- a/sparse/etc/appsupport.conf.d/20-s19mps.conf
+++ b/sparse/etc/appsupport.conf.d/20-s19mps.conf
@@ -1,10 +1,8 @@
 [Config]
-Proxies=android.hardware.media.c2@1.0::IComponentStore,android.hardware.media.c2@1.1::IComponentStore/default
 CustomProperties=persist.log.tag=I
 CustomProperties=log.tag.gralloc4=W
 
 [Devices]
-DevNodes=mali0
 DevNodes=pmsg0
 AppSupportRadioEnabled=true
 

--- a/sparse/opt/appsupport/vendor/etc/vintf/manifest/power.xml
+++ b/sparse/opt/appsupport/vendor/etc/vintf/manifest/power.xml
@@ -3,4 +3,9 @@
         <name>android.hardware.power</name>
         <transport>hwbinder</transport>
     </hal>
+    <hal format="aidl">
+        <name>android.hardware.power</name>
+        <version>2</version>
+    <fqname>IPower/default</fqname>
+    </hal>
 </manifest>


### PR DESCRIPTION
[s19mps] Use host AIDL power HAL in AppSupport. JB#63829